### PR TITLE
Support custom labels and annotiations for service and deployment

### DIFF
--- a/helm/enterprise/Chart.yaml
+++ b/helm/enterprise/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/enterprise/templates/deployment.yaml
+++ b/helm/enterprise/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "portkeyenterprise.fullname" . }}
   labels:
     {{- include "portkeyenterprise.labels" . | nindent 4 }}
+    {{- with .Values.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm/enterprise/templates/service.yaml
+++ b/helm/enterprise/templates/service.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "portkeyenterprise.fullname" . }}
   labels:
     {{- include "portkeyenterprise.labels" . | nindent 4 }}
+    {{- with .Values.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/enterprise/values.yaml
+++ b/helm/enterprise/values.yaml
@@ -74,6 +74,8 @@ securityContext: {}
 service:
   type: NodePort
   port: 8787
+  additionalLabels: {}
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
This is to provide helm chart users to pass custom labels and annotations in Service. 
This is important in scenarios where internal infra teams depend on certain labels/annotations for integration.